### PR TITLE
Fix persisting the scrollTop on item updates

### DIFF
--- a/addon/components/virtual-each.js
+++ b/addon/components/virtual-each.js
@@ -164,7 +164,7 @@ const VirtualEachComponent = Component.extend(EventListenerMixin, DefaultAttrsMi
     const sanitizedIndex = Math.min(startingIndex, maxVisibleItemTop);
     const sanitizedPadding = (startingPadding > maxPadding) ? maxPadding : startingPadding;
 
-    emberRun.scheduleOnce('afterRender', () => {
+    this.scheduledRender = emberRun.scheduleOnce('afterRender', () => {
       this.calculateVisibleItems(sanitizedIndex);
       this.$().scrollTop(sanitizedPadding);
     });
@@ -182,6 +182,11 @@ const VirtualEachComponent = Component.extend(EventListenerMixin, DefaultAttrsMi
         _totalHeight: Math.max(get(items, 'length') * this.getAttr('itemHeight'), 0)
       });
     });
+  },
+
+  willDestroyElement() {
+    this._super(...arguments);
+    Ember.run.cancel(this.scheduledRender);
   }
 });
 

--- a/addon/components/virtual-each.js
+++ b/addon/components/virtual-each.js
@@ -167,6 +167,19 @@ const VirtualEachComponent = Component.extend(EventListenerMixin, DefaultAttrsMi
     this.$().scrollTop(sanitizedPadding);
   },
 
+  positionIndexDidChange(oldAttrs, newAttrs){
+    if(newAttrs && newAttrs.hasOwnProperty('positionIndex')){
+      let newPositionIndex = newAttrs.positionIndex.value;
+      if(oldAttrs && oldAttrs.hasOwnProperty('positionIndex')){
+        let oldPositionIndex = oldAttrs.positionIndex.value;
+        return oldPositionIndex !== newPositionIndex;
+      } else {
+        return true;
+      }
+    }
+    return false;
+  },
+
   didReceiveAttrs(attrs) {
     this._super(...arguments);
 
@@ -178,7 +191,7 @@ const VirtualEachComponent = Component.extend(EventListenerMixin, DefaultAttrsMi
         _totalHeight: Math.max(get(items, 'length') * this.getAttr('itemHeight'), 0)
       });
 
-      if (attrs.newAttrs.hasOwnProperty('items') || attrs.newAttrs.hasOwnProperty('positionIndex')) {
+      if(this.positionIndexDidChange(attrs.oldAttrs, attrs.newAttrs)){
         emberRun.scheduleOnce('afterRender', () => {
           this.scrollTo(this.getAttr('positionIndex'));
         });

--- a/tests/unit/virtual-each-test.js
+++ b/tests/unit/virtual-each-test.js
@@ -244,23 +244,44 @@ describeComponent('virtual-each', 'VirtualEachComponent', {
 
       describe("positioning to the last item in list", function() {
         beforeEach(function() {
+          let totalHeight = 200*35;
+          let virtualHeight = 500;
+          this.expectedScrollTop = totalHeight - virtualHeight;
           run(() => {
             this.set('positionIndex', 199);
           });
         });
 
-        it("is the last item in the list", function() {
+        it("positions the last item at the bottom of the list", function() {
           var $component = this.$('.virtual-each');
+          expect($component.find('li').first().text()).to.contain('Item 185');
           expect($component.find('li').last().text()).to.contain('Item 199');
         });
 
-        it("sets the scrollTop such that the last item exists is the last visible item", function() {
+        it("sets the scrollTop to the total height less the virtual height", function() {
           var $component = this.$('.virtual-each');
-          let totalHeight = 200*35;
-          let virtualHeight = 500;
+          expect($component.scrollTop()).to.be.closeTo(this.expectedScrollTop, SCROLL_TOP_BUFFER);
+        });
 
-          let expectedScrollTop = totalHeight - virtualHeight;
-          expect($component.scrollTop()).to.be.closeTo(expectedScrollTop, SCROLL_TOP_BUFFER);
+        describe("receiving new items", function() {
+          beforeEach(function() {
+            return run(() => {
+              let items = this.get('items')
+                    .concat(this.get('items'))
+                    .map((value, index)=> { return "Item ".concat(index); });
+              return this.set('items', items);
+            });
+          });
+
+          it("persists the current index", function() {
+            var $component = this.$('.virtual-each');
+            expect($component.find('li').first().text()).to.contain('Item 185');
+          });
+
+          it("persists the scrollTop", function() {
+            var $component = this.$('.virtual-each');
+            expect($component.scrollTop()).to.be.closeTo(this.expectedScrollTop, SCROLL_TOP_BUFFER);
+          });
         });
       });
 
@@ -297,8 +318,10 @@ describeComponent('virtual-each', 'VirtualEachComponent', {
 
           describe("updating items", function() {
             beforeEach(function() {
-              let newItems = this.get('items').map((value, index)=> { return "newItem ".concat(index); });
-              this.set('items', newItems);
+              run(() => {
+                let updatedItems = this.get('items').map((value, index)=> { return "newItem ".concat(index); });
+                this.set('items', updatedItems);
+              });
             });
 
             it("persists the current index", function() {


### PR DESCRIPTION
Fixes #31 

`scrollTo` was being called too frequently. It's necessary to scroll to a new item on init, and whenever the `positionIndex` attribute changes. Here we implement an observer on `_positionIndex`, which only fires whenever `positionIndex` changes.

In addition we have written [tests](https://github.com/jasonmit/virtual-each/blob/persist-scroll-top/tests/unit/virtual-each-test.js#L281-L284) which exercise the related issues.