### PR TITLE
Track if the items array is changed to recalculate visibleItems

### DIFF
--- a/addon/components/virtual-each/component.js
+++ b/addon/components/virtual-each/component.js
@@ -74,7 +74,7 @@ const VirtualEachComponent = Component.extend(EventListenerMixin, DefaultAttrsMi
     }
   }).readOnly(),
 
-  visibleItems: computed('_startAt', '_visibleItemCount', '_items', 'rowPadding', {
+  visibleItems: computed('_startAt', '_visibleItemCount', '_items.[]', 'rowPadding', {
     get() {
       const items = get(this, '_items');
       const startAt = get(this, '_startAt');

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "ember": "~2.7.0",
     "ember-cli-shims": "0.1.1",
     "mocha": "~2.2.4",
-    "chai": "~2.3.0",
     "ember-mocha-adapter": "~0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ember-browsery-stats": "0.1.1",
     "ember-cli": "2.11.0",
     "ember-cli-app-version": "^2.0.1",
+    "ember-cli-chai": "0.3.2",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-github-pages": "0.1.2",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",

--- a/tests/dummy/app/templates/components/x-people.hbs
+++ b/tests/dummy/app/templates/components/x-people.hbs
@@ -1,9 +1,10 @@
 {{#virtual-each
+  items
   height=height
   itemHeight=36
   scrollTimeout=scrollTimeout
   positionIndex=positionIndex
-  items=items as |item index|
+ as |item index|
 }}
   <div class="person-row">
     <div class="count">{{index}}</div>

--- a/tests/unit/virtual-each-test.js
+++ b/tests/unit/virtual-each-test.js
@@ -329,6 +329,24 @@ describeComponent('virtual-each', 'VirtualEachComponent', {
               expect($component.find('li').last().text()).to.contain('actual 199');
             });
           });
+
+          describe("rerendering when items are added or removed", function() {
+            it('renders the new item correctly', function() {
+                run(() => {
+                    this.get('items').pushObject('newItem 200');
+                });
+                var $component = this.$('.virtual-each');
+                expect($component.find('li').last().text()).to.contain('newItem 200');
+            });
+
+            it('removes deleted item from the visible list', function() {
+                run(() => {
+                    this.get('items').popObject();
+                });
+                var $component = this.$('.virtual-each');
+                expect($component.find('li').last().text()).to.contain('actual 198');
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
The dependencies of the `visibleItems` computed property have been changed to track whether new items are added to or removed from the `items` array. 

On the project I work on we have a case where changes to the list on are only reflected when it's scrolled. 

I added two failing tests for both cases, but I am not sure if I placed the tests in the appropriate `describe` block. All tests are passing after the change.

However I had to switch the bower chai package for ember-cli-chai to be able to run the tests at all. Please let me know if that is ok or I need to revert it.  Seems like this causes the current build in travis to fail as well.

I don't think the change to the computed property impacts performance in any way, but I don't have any benchmarks to prove it, other than playing with the dummy app and our app for a bit. 

Thanks for all the work on the addon so far and please let know if there's more to be done here. 
