### PR TITLE
Getter function to work with `defaultAttrs` of computed property type

### DIFF
--- a/addon/mixins/default-attrs.js
+++ b/addon/mixins/default-attrs.js
@@ -13,7 +13,7 @@ export default Ember.Mixin.create({
     const value = this._super(...arguments);
 
     if (typeof value === 'undefined') {
-      return this.defaultAttrs[attrName];
+      return this.get(`defaultAttrs.${attrName}`);
     }
 
     return value;

--- a/app/mixins/default-attrs.js
+++ b/app/mixins/default-attrs.js
@@ -1,0 +1,1 @@
+export { default } from 'virtual-each/mixins/default-attrs';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtual-each",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A port of react-infinite-list to Ember.",
   "directories": {
     "doc": "doc",

--- a/tests/unit/mixins/default-attrs-getter-test.js
+++ b/tests/unit/mixins/default-attrs-getter-test.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import EmberObject, { computed } from '@ember/object';
+import DefaultAttrsMixin from 'virtual-each/mixins/default-attrs';
+
+describe('Default Attrs Mixin', function() {
+  it('gets a value from plain object', function() {
+    let mixin = EmberObject.extend(DefaultAttrsMixin).create();
+    mixin.defaultAttrs.positionIndex = 5;
+
+    expect(mixin.getAttr('positionIndex')).to.equal(5);
+  });
+
+  it('gets a value from computed property', function() {
+    let mixin = EmberObject.extend(DefaultAttrsMixin, {
+      defaultAttrs: computed(function() {
+        return {
+          positionIndex: 5
+        };
+      })
+    }).create();
+
+    expect(mixin.getAttr('positionIndex')).to.equal(5);
+  });
+});


### PR DESCRIPTION
## Changes
-  ``getAttr()`` of ``default-attrs`` mixin to use Ember's ``get`` to fetch attribute off of ``defaultAttrs`` object.

## Why
I've made a screenshot of the error stacktrace to show why this PR got submitted :1st_place_medal:.
![image](https://user-images.githubusercontent.com/15948633/42280256-7f8c1db8-7fa0-11e8-90fb-96dfddc0c5bb.png)

While using ``paper-chips`` from ``ember-paper`` which depends on ``virtual-each`` every time I typed in something to the input, I've had such error logged to console.
After changing the getter to use  Ember's ``get`` I've got rid of this error.

But the real ``Why`` is that, the folks @ember-paper declare ``defaultAttrs`` as computed property, and so the errors were raised.

Using ``computed`` without dependent keys is pretty common after all, so It'd be nice if it was computedProperty compatible.